### PR TITLE
Add support for package Foo::Bar v1.2.3;

### DIFF
--- a/examples/perl-reversion
+++ b/examples/perl-reversion
@@ -224,9 +224,9 @@ sub version_re_perl_pack {
   my $ver_re = shift;
 
   return
-   qr{ ^(\s*package\s+\w+[:\w]*\s+ \D* )
+   qr{ ^(\s* package \s+ (?: \w+ (?: (?: :: | ' ) \w+ )* \s+ ))
                  $ver_re
-                 ( .* ) $ }x;
+                 ( .* \s* ) \z }x;
 }
 
 
@@ -359,6 +359,10 @@ sub find_versions {
         {
           re   => qr{ ^ = (?! cut ) }x,
           goto => 'pod',
+        },
+        {
+          re   => version_re_perl_pack( $ver_re ),
+          mark => 1,
         },
         {
           re   => version_re_perl( $ver_re ),

--- a/examples/perl-reversion
+++ b/examples/perl-reversion
@@ -140,7 +140,7 @@ my @skip = ( qw( .svn .git CVS .DS_Store ), @dir_skip );
 # regex, but I fixed the regex for precedence with anchors, and
 # quotemeta everything.
 my $SKIP = '^( ' . join( ' | ', map { quotemeta($_) } @skip ) . ' )$';
-note( "Regex is $SKIP" );
+#note( "Regex is $SKIP\n" );
 $SKIP = qr/$SKIP/x;
 
 my @files = @ARGV ? expand_dirs( @ARGV ) : find_proj_files();
@@ -296,7 +296,7 @@ sub set_versions {
 sub find_version_for_doc {
   my ( $ver_found, $version, $name, $info, $machine ) = @_;
 
-  note( "Scanning $name" );
+  note( "Scanning $name\n" );
 
   my $state = $machine->{init};
   my $lines = $info->{lines};

--- a/t/40.perl-reversion.t
+++ b/t/40.perl-reversion.t
@@ -70,7 +70,7 @@ sub count_newlines {
     my %result;
     for my $name (@_) {
         my $content= read_file($name, binmode => ':raw' );
-        
+
         $result{ $name }= +{
             map {
                 my $key= unpack 'H*', $_;
@@ -85,7 +85,7 @@ sub count_newlines {
 sub ok_newlines {
     my( $name, %expected ) = @_;
     my %got= count_newlines( keys %expected );
-    
+
     is_deeply \%got, \%expected,
         "$name - All newlines remain intact"
       or diag Dumper [ \%expected, \%got ];
@@ -94,11 +94,11 @@ sub ok_newlines {
 
 sub runtests {
   my ( $name, $version ) = @_;
-  
+
   # Check that we keep line endings consistent:
   my @files= (grep { -f } glob( "$dir/*" ), glob( "$dir/*/*" ) );
   my %newlines= count_newlines( @files );
-  
+
   is_deeply( find( $dir ), { found => '1.2.3' }, "found in $name" );
   is_deeply( find( $dir, "-current=1.2" ),
     {}, "partial does not match" );

--- a/t/40.perl-reversion.t
+++ b/t/40.perl-reversion.t
@@ -20,7 +20,6 @@ my $RUN = "$^X $libs examples/perl-reversion";
 if ( system( "$RUN -quiet" ) ) {
   plan skip_all => 'cannot run perl-reversion, skipping its tests';
 }
-plan tests => 45;
 
 my $dir = File::Temp::tempdir( CLEANUP => 1 );
 
@@ -213,3 +212,5 @@ with_file(
   README => "This README describes\x{0d}\x{0a}version 1.2.3 of\x{0d}\x{0a}Flurble.\x{0a}",
   sub { runtests( newlines => "1.2.3" ) },
 );
+
+done_testing();

--- a/t/40.perl-reversion.t
+++ b/t/40.perl-reversion.t
@@ -184,6 +184,35 @@ END
 );
 
 with_file(
+  "Foo.pm", <<'END',
+package Foo v1.2.3;
+1;
+END
+  sub {
+    is_deeply( find( $dir ), { found => 'v1.2.3' }, "package-v-string found in pm" );
+    _run( $dir, '-set', '1.2' );
+    is_deeply( find( $dir ), { found => 'v1.2' }, "set version keeps v prefix" );
+    _run( $dir, '-bump' );
+    is_deeply( find( $dir ), { found => 'v1.3' }, "bump subversion with v prefix" );
+  },
+);
+
+with_file(
+  "Foo.pm", <<'END',
+package Foo 1.0;
+1;
+END
+  sub {
+    #my %newlines= count_newlines( @files );
+    is_deeply( find( $dir ), { found => '1.0' }, "package version found in pm" );
+    _run( $dir, '-set', '1.2' );
+    _run( $dir, '-bump' );
+    is_deeply( find( $dir ), { found => '1.3' }, "bump version without v prefix" );
+    #ok_newlines(\%newlines);
+  },
+);
+
+with_file(
   README => <<'END',
 This README describes version 1.2.3 of Flurble.
 END

--- a/t/40.perl-reversion.t
+++ b/t/40.perl-reversion.t
@@ -22,7 +22,7 @@ my $RUN = "$^X $libs examples/perl-reversion";
 if ( system( "$RUN -quiet" ) ) {
   plan skip_all => 'cannot run perl-reversion, skipping its tests';
 }
-plan tests => 44;
+plan tests => 45;
 
 my $dir = File::Temp::tempdir( CLEANUP => 1 );
 
@@ -177,6 +177,7 @@ END
   sub {
     is_deeply( find( $dir ), { found => 'v1.2.3' }, "found in pm" );
     _run( $dir, '-set', '1.2' );
+    is_deeply( find( $dir ), { found => 'v1.2' }, "set subversion keeps v prefix" );
     _run( $dir, '-bump' );
     is_deeply( find( $dir ), { found => 'v1.3' }, "bump subversion with v prefix" );
   },


### PR DESCRIPTION
Currently, the following syntax is not detected and bumped:

```perl

package Foo::Bar v1.2.3;
```

This patch adds support for that.