### PR TITLE
Win32 test

### DIFF
--- a/t/40.perl-reversion.t
+++ b/t/40.perl-reversion.t
@@ -10,9 +10,9 @@ use FileHandle;
 use File::Slurp::Tiny qw(read_file);
 use Data::Dumper;
 
-if ( $^O =~ /MSWin32/ ) {
-  plan skip_all => 'cannot run on Windows';
-}
+#if ( $^O =~ /MSWin32/ ) {
+#  plan skip_all => 'cannot run on Windows';
+#}
 
 # -Mblib makes a lot of noise
 my $libs = join " ",
@@ -39,16 +39,7 @@ sub find {
 sub _run {
   my $cmd = "$RUN @_";
   #diag $cmd;
-  my $output;
-  my $pid = open my $fh, '-|';
-  die "Could not open pipe: $!" unless defined $pid;
-  if ( $pid ) {
-    $output = join '', <$fh>;
-  }
-  else {
-    close *STDERR;
-    exec $cmd;
-  }
+  my $output = readpipe( $cmd );
 
   #diag $output;
   return { output => $output };


### PR DESCRIPTION
This patch (re)enables the test of `perl-reversion` on Windows.

It has the slightly inconvenient side-effect of letting STDERR of the child through. If that is really unwanted, I will look at how to suppress it. Most likely, this can be done through

```
my $devnull = File::Spec->devnull;
my $output = readpipe("$cmd 2>$devnull");
```

but if this change already is enough, it would be nice to have all tests run on Windows.